### PR TITLE
jQuery() wants a callback to properly handle the document ready situatio...

### DIFF
--- a/jQl.js
+++ b/jQl.js
@@ -121,7 +121,7 @@ var jQl={
 
 		// and last unqueue all inline calls
 		// (when document is ready)
-		jQuery(jQl.unq());
+		jQuery(jQl.unq);
 
 		// call the callback if provided
 		if(typeof callback=='function') callback();


### PR DESCRIPTION
Calling jQuery(function(){}) instead jQuery(function(){}()) to let jQuery properly handle the document ready
